### PR TITLE
Skip not loaded embeddables

### DIFF
--- a/src/Enum/EnumPostLoadEntityListener.php
+++ b/src/Enum/EnumPostLoadEntityListener.php
@@ -48,11 +48,16 @@ class EnumPostLoadEntityListener
 	{
 		$metadata = $this->getClassMetadata($entityManager, get_class($entity));
 
-		list($object, $classReflection, $propertyName) = $this->resolveObjectAndProperty(
-			$entityManager,
-			$entity,
-			$fieldName
-		);
+		try {
+			list($object, $classReflection, $propertyName) = $this->resolveObjectAndProperty(
+				$entityManager,
+				$entity,
+				$fieldName
+			);
+		} catch (\Consistence\Doctrine\Enum\EmbeddableIsNullException $e) {
+			return;
+		}
+
 		$property = $this->getProperty($classReflection, $propertyName);
 		$annotation = $this->annotationReader->getPropertyAnnotation($property, EnumAnnotation::class);
 		if ($annotation !== null) {
@@ -102,6 +107,10 @@ class EnumPostLoadEntityListener
 		string $fieldName
 	): array
 	{
+		if ($object === null) {
+			throw new \Consistence\Doctrine\Enum\EmbeddableIsNullException();
+		}
+
 		$metadata = $this->getClassMetadata($entityManager, get_class($object));
 
 		$parts = explode(self::EMBEDDED_SEPARATOR, $fieldName);

--- a/src/Enum/exceptions/EmbeddableIsNullException.php
+++ b/src/Enum/exceptions/EmbeddableIsNullException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Consistence\Doctrine\Enum;
+
+/**
+ * @internal
+ */
+class EmbeddableIsNullException extends \Consistence\PhpException
+{
+
+}

--- a/tests/Enum/LoadEnumToEntityIntegrationTest.php
+++ b/tests/Enum/LoadEnumToEntityIntegrationTest.php
@@ -7,6 +7,7 @@ namespace Consistence\Doctrine\Enum;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Tools\Setup;
+use ReflectionProperty;
 
 class LoadEnumToEntityIntegrationTest extends \PHPUnit\Framework\TestCase
 {
@@ -84,6 +85,18 @@ class LoadEnumToEntityIntegrationTest extends \PHPUnit\Framework\TestCase
 		} catch (\Consistence\Doctrine\Enum\NotEnumException $e) {
 			$this->assertSame(FooEntity::class, $e->getEnumClass());
 		}
+	}
+
+	public function testLoadEnumInNullEmbeddable()
+	{
+		$foo = new FooEntity();
+		$property = new ReflectionProperty(FooEntity::class, 'embedded');
+		$property->setAccessible(true);
+		$property->setValue($foo, null);
+
+		$this->callPostLoadEventOnEntity($foo);
+
+		$this->assertNull($property->getValue($foo));
 	}
 
 	/**


### PR DESCRIPTION
Current implementation has problems with Doctrine [Partial Objects](http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/partial-objects.html).

Consider following scenario (ORM annotations omitted for clarity):
```php
class FooEntity
{

    /** @var int */
    private $id;

    /** @var BarEmbeddable */
    private $bar; 

}
```
When FooEntity is loaded partially:
```sql
select partial e.{id} from FooEntity e
```
postLoad event is dispatched, but EnumPostLoadListener crashes, because it expects, that embeddables (FooEntity::$bar) are always objects.

EnumPostLoadListener should skip those embeddables and not crash