### PR TITLE
Fix incorrect annotation name

### DIFF
--- a/tests/Enum/data/FooParentEntity.php
+++ b/tests/Enum/data/FooParentEntity.php
@@ -7,7 +7,7 @@ namespace Consistence\Doctrine\Enum;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * @ORM\MappedSuperClass
+ * @ORM\MappedSuperclass
  */
 class FooParentEntity
 {


### PR DESCRIPTION
When the dependency is `doctrine/orm: ^2.6.3` then highest depdenencies builds are failing, but lowest dependencies are okay: https://github.com/consistence/consistence-doctrine/actions/runs/4026729820

With `doctrine/orm: 2.14` (locked) everything is failing: https://github.com/consistence/consistence-doctrine/actions/runs/4026706740 .

With `doctrine/orm: 2.13.5` (locked) everything is OK: https://github.com/consistence/consistence-doctrine/actions/runs/4026766351 .

Based on that I have isolated the break to https://github.com/doctrine/orm/pull/10321 , which was introduced in `2.14`. If I update my local vendor on `2.14` with reverted changes from this PR, then everything starts working again.

The fact, that it was not working only for `@Doctrine\ORM\Mapping\MappedSuperClass`, but for everything else it did, led me to guessing that this is an autoloading issue and indeed it was.