### PR TITLE
Refactor tests

### DIFF
--- a/tests/Enum/EnumPostLoadEntityListenerTest.php
+++ b/tests/Enum/EnumPostLoadEntityListenerTest.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\ClassMetadata as PersistenceClassMetadata;
+use PHPUnit\Framework\Assert;
 
 class EnumPostLoadEntityListenerTest extends \PHPUnit\Framework\TestCase
 {
@@ -24,16 +25,16 @@ class EnumPostLoadEntityListenerTest extends \PHPUnit\Framework\TestCase
 
 		$entityManager = $this->createMock(EntityManager::class);
 		$entityManager
-			->expects($this->once())
+			->expects(self::once())
 			->method('getClassMetadata')
-			->will($this->returnValue($classMetadata));
+			->will(self::returnValue($classMetadata));
 
 		$loadEvent = new LifecycleEventArgs(new FooEntity(), $entityManager);
 
 		try {
 			$postLoadListener->postLoad($loadEvent);
 		} catch (\Consistence\Doctrine\Enum\UnsupportedClassMetadataException $e) {
-			$this->assertSame(get_class($classMetadata), $e->getGivenClassMetadataClass());
+			Assert::assertSame(get_class($classMetadata), $e->getGivenClassMetadataClass());
 		}
 	}
 
@@ -48,13 +49,13 @@ class EnumPostLoadEntityListenerTest extends \PHPUnit\Framework\TestCase
 
 		$entityManager = $this->createMock(EntityManager::class);
 		$entityManager
-			->expects($this->once())
+			->expects(self::once())
 			->method('getClassMetadata')
-			->will($this->returnValue($classMetadata));
+			->will(self::returnValue($classMetadata));
 
 		$postLoadListener->warmUpCache($entityManager, FooEntity::class);
 
-		$this->assertTrue($cache->contains(FooEntity::class));
+		Assert::assertTrue($cache->contains(FooEntity::class));
 	}
 
 }

--- a/tests/Enum/EnumPostLoadEntityListenerTest.php
+++ b/tests/Enum/EnumPostLoadEntityListenerTest.php
@@ -33,6 +33,7 @@ class EnumPostLoadEntityListenerTest extends \PHPUnit\Framework\TestCase
 
 		try {
 			$postLoadListener->postLoad($loadEvent);
+			Assert::fail('Exception expected');
 		} catch (\Consistence\Doctrine\Enum\UnsupportedClassMetadataException $e) {
 			Assert::assertSame(get_class($classMetadata), $e->getGivenClassMetadataClass());
 		}

--- a/tests/Enum/LoadEnumToEntityIntegrationTest.php
+++ b/tests/Enum/LoadEnumToEntityIntegrationTest.php
@@ -7,6 +7,7 @@ namespace Consistence\Doctrine\Enum;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Tools\Setup;
+use PHPUnit\Framework\Assert;
 
 class LoadEnumToEntityIntegrationTest extends \PHPUnit\Framework\TestCase
 {
@@ -16,7 +17,7 @@ class LoadEnumToEntityIntegrationTest extends \PHPUnit\Framework\TestCase
 		$foo = new FooEntity();
 		$this->callPostLoadEventOnEntity($foo);
 
-		$this->assertSame(FooEnum::get(FooEnum::ONE), $foo->getEnum());
+		Assert::assertSame(FooEnum::get(FooEnum::ONE), $foo->getEnum());
 	}
 
 	public function testLoadNullEnumToEntity(): void
@@ -24,7 +25,7 @@ class LoadEnumToEntityIntegrationTest extends \PHPUnit\Framework\TestCase
 		$foo = new FooEntity();
 		$this->callPostLoadEventOnEntity($foo);
 
-		$this->assertNull($foo->getNullableEnum());
+		Assert::assertNull($foo->getNullableEnum());
 	}
 
 	public function testLoadEnumToUnserializedEntity(): void
@@ -35,8 +36,8 @@ class LoadEnumToEntityIntegrationTest extends \PHPUnit\Framework\TestCase
 		$foo = unserialize(serialize($fooBeforeSerialization));
 		$this->callPostLoadEventOnEntity($foo);
 
-		$this->assertSame(FooEnum::get(FooEnum::ONE), $foo->getEnum());
-		$this->assertNull($foo->getNullableEnum());
+		Assert::assertSame(FooEnum::get(FooEnum::ONE), $foo->getEnum());
+		Assert::assertNull($foo->getNullableEnum());
 	}
 
 	public function testMultipleLoadEvents(): void
@@ -45,7 +46,7 @@ class LoadEnumToEntityIntegrationTest extends \PHPUnit\Framework\TestCase
 		$this->callPostLoadEventOnEntity($foo);
 		$this->callPostLoadEventOnEntity($foo);
 
-		$this->assertSame(FooEnum::get(FooEnum::ONE), $foo->getEnum());
+		Assert::assertSame(FooEnum::get(FooEnum::ONE), $foo->getEnum());
 	}
 
 	public function testLoadEnumClassWithoutNamespace(): void
@@ -53,7 +54,7 @@ class LoadEnumToEntityIntegrationTest extends \PHPUnit\Framework\TestCase
 		$foo = new FooEntity();
 		$this->callPostLoadEventOnEntity($foo);
 
-		$this->assertSame(FooEnum::get(FooEnum::ONE), $foo->getWithoutNamespace());
+		Assert::assertSame(FooEnum::get(FooEnum::ONE), $foo->getWithoutNamespace());
 	}
 
 	public function testLoadEnumInEmbeddable(): void
@@ -61,7 +62,7 @@ class LoadEnumToEntityIntegrationTest extends \PHPUnit\Framework\TestCase
 		$foo = new FooEntity();
 		$this->callPostLoadEventOnEntity($foo);
 
-		$this->assertSame(FooEnum::get(FooEnum::ONE), $foo->getEmbedded()->getEnum());
+		Assert::assertSame(FooEnum::get(FooEnum::ONE), $foo->getEmbedded()->getEnum());
 	}
 
 	public function testLoadEnumInEmbeddableWeNeedToGoDeeper(): void
@@ -69,7 +70,7 @@ class LoadEnumToEntityIntegrationTest extends \PHPUnit\Framework\TestCase
 		$foo = new FooEntity();
 		$this->callPostLoadEventOnEntity($foo);
 
-		$this->assertSame(FooEnum::get(FooEnum::ONE), $foo->getEmbedded()->getEmbedded()->getEnum());
+		Assert::assertSame(FooEnum::get(FooEnum::ONE), $foo->getEmbedded()->getEmbedded()->getEnum());
 	}
 
 	public function testLoadEnumInNotLoadedEmbeddable(): void
@@ -77,7 +78,7 @@ class LoadEnumToEntityIntegrationTest extends \PHPUnit\Framework\TestCase
 		$foo = new FooEntity();
 		$this->callPostLoadEventOnEntity($foo);
 
-		$this->assertNull($foo->getNotLoadedEmbedded());
+		Assert::assertNull($foo->getNotLoadedEmbedded());
 	}
 
 	public function testLoadEnumMissingEnumClass(): void
@@ -93,7 +94,7 @@ class LoadEnumToEntityIntegrationTest extends \PHPUnit\Framework\TestCase
 		try {
 			$this->callPostLoadEventOnEntity(new BazEntity());
 		} catch (\Consistence\Doctrine\Enum\NotEnumException $e) {
-			$this->assertSame('Consistence\Doctrine\Enum\NonExistingClass', $e->getEnumClass());
+			Assert::assertSame('Consistence\Doctrine\Enum\NonExistingClass', $e->getEnumClass());
 		}
 	}
 
@@ -102,7 +103,7 @@ class LoadEnumToEntityIntegrationTest extends \PHPUnit\Framework\TestCase
 		try {
 			$this->callPostLoadEventOnEntity(new BaxEntity());
 		} catch (\Consistence\Doctrine\Enum\NotEnumException $e) {
-			$this->assertSame(FooEntity::class, $e->getEnumClass());
+			Assert::assertSame(FooEntity::class, $e->getEnumClass());
 		}
 	}
 
@@ -116,8 +117,8 @@ class LoadEnumToEntityIntegrationTest extends \PHPUnit\Framework\TestCase
 		$postLoadListener->postLoad(new LifecycleEventArgs($foo, $entityManager));
 		$postLoadListener->postLoad(new LifecycleEventArgs($iAmFooToo, $entityManager));
 
-		$this->assertSame(FooEnum::get(FooEnum::ONE), $foo->getEnum());
-		$this->assertSame(FooEnum::get(FooEnum::ONE), $iAmFooToo->getEnum());
+		Assert::assertSame(FooEnum::get(FooEnum::ONE), $foo->getEnum());
+		Assert::assertSame(FooEnum::get(FooEnum::ONE), $iAmFooToo->getEnum());
 	}
 
 	private function callPostLoadEventOnEntity(object $entity): void

--- a/tests/Enum/LoadEnumToEntityIntegrationTest.php
+++ b/tests/Enum/LoadEnumToEntityIntegrationTest.php
@@ -93,6 +93,7 @@ class LoadEnumToEntityIntegrationTest extends \PHPUnit\Framework\TestCase
 	{
 		try {
 			$this->callPostLoadEventOnEntity(new BazEntity());
+			Assert::fail('Exception expected');
 		} catch (\Consistence\Doctrine\Enum\NotEnumException $e) {
 			Assert::assertSame('Consistence\Doctrine\Enum\NonExistingClass', $e->getEnumClass());
 		}
@@ -102,6 +103,7 @@ class LoadEnumToEntityIntegrationTest extends \PHPUnit\Framework\TestCase
 	{
 		try {
 			$this->callPostLoadEventOnEntity(new BaxEntity());
+			Assert::fail('Exception expected');
 		} catch (\Consistence\Doctrine\Enum\NotEnumException $e) {
 			Assert::assertSame(FooEntity::class, $e->getEnumClass());
 		}

--- a/tests/Enum/LoadEnumToEntityIntegrationTest.php
+++ b/tests/Enum/LoadEnumToEntityIntegrationTest.php
@@ -75,23 +75,35 @@ class LoadEnumToEntityIntegrationTest extends \PHPUnit\Framework\TestCase
 		$this->callPostLoadEventOnEntity(new BarEntity());
 	}
 
-	public function testLoadEnumNonExistingEnumClass(): void
+	public function loadEnumNotEnumClassDataProvider(): Generator
 	{
-		try {
-			$this->callPostLoadEventOnEntity(new BazEntity());
-			Assert::fail('Exception expected');
-		} catch (\Consistence\Doctrine\Enum\NotEnumException $e) {
-			Assert::assertSame('Consistence\Doctrine\Enum\NonExistingClass', $e->getEnumClass());
-		}
+		yield 'non-existing class' => [
+			'entity' => new BazEntity(),
+			'expectedNotEnumClass' => 'Consistence\Doctrine\Enum\NonExistingClass',
+		];
+
+		yield 'not enum class' => [
+			'entity' => new BaxEntity(),
+			'expectedNotEnumClass' => FooEntity::class,
+		];
 	}
 
-	public function testLoadEnumNotEnumClass(): void
+	/**
+	 * @dataProvider loadEnumNotEnumClassDataProvider
+	 *
+	 * @param object $entity
+	 * @param string $expectedNotEnumClass
+	 */
+	public function testLoadEnumNotEnumClass(
+		object $entity,
+		string $expectedNotEnumClass
+	): void
 	{
 		try {
-			$this->callPostLoadEventOnEntity(new BaxEntity());
+			$this->callPostLoadEventOnEntity($entity);
 			Assert::fail('Exception expected');
 		} catch (\Consistence\Doctrine\Enum\NotEnumException $e) {
-			Assert::assertSame(FooEntity::class, $e->getEnumClass());
+			Assert::assertSame($expectedNotEnumClass, $e->getEnumClass());
 		}
 	}
 

--- a/tests/Enum/Type/EnumTypeIntegrationTest.php
+++ b/tests/Enum/Type/EnumTypeIntegrationTest.php
@@ -18,10 +18,26 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function convertEnumToDatabaseDataProvider(): Generator
 	{
-		yield [DoctrineType::getType(FloatEnumType::NAME), FooFloatEnum::get(FooFloatEnum::ONE), FooFloatEnum::ONE];
-		yield [DoctrineType::getType(IntegerEnumType::NAME), FooIntegerEnum::get(FooIntegerEnum::ONE), FooIntegerEnum::ONE];
-		yield [DoctrineType::getType(StringEnumType::NAME), FooStringEnum::get(FooStringEnum::ONE), FooStringEnum::ONE];
-		yield [DoctrineType::getType(BooleanEnumType::NAME), FooBooleanEnum::get(FooBooleanEnum::ENABLED), FooBooleanEnum::ENABLED];
+		yield [
+			DoctrineType::getType(FloatEnumType::NAME),
+			FooFloatEnum::get(FooFloatEnum::ONE),
+			FooFloatEnum::ONE,
+		];
+		yield [
+			DoctrineType::getType(IntegerEnumType::NAME),
+			FooIntegerEnum::get(FooIntegerEnum::ONE),
+			FooIntegerEnum::ONE,
+		];
+		yield [
+			DoctrineType::getType(StringEnumType::NAME),
+			FooStringEnum::get(FooStringEnum::ONE),
+			FooStringEnum::ONE,
+		];
+		yield [
+			DoctrineType::getType(BooleanEnumType::NAME),
+			FooBooleanEnum::get(FooBooleanEnum::ENABLED),
+			FooBooleanEnum::ENABLED,
+		];
 	}
 
 	/**
@@ -42,10 +58,18 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function enumTypeDataProvider(): Generator
 	{
-		yield [DoctrineType::getType(FloatEnumType::NAME)];
-		yield [DoctrineType::getType(IntegerEnumType::NAME)];
-		yield [DoctrineType::getType(StringEnumType::NAME)];
-		yield [DoctrineType::getType(BooleanEnumType::NAME)];
+		yield [
+			DoctrineType::getType(FloatEnumType::NAME),
+		];
+		yield [
+			DoctrineType::getType(IntegerEnumType::NAME),
+		];
+		yield [
+			DoctrineType::getType(StringEnumType::NAME),
+		];
+		yield [
+			DoctrineType::getType(BooleanEnumType::NAME),
+		];
 	}
 
 	/**
@@ -64,10 +88,22 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function convertScalarValueToDatabaseDataProvider(): Generator
 	{
-		yield [DoctrineType::getType(FloatEnumType::NAME), FooFloatEnum::ONE];
-		yield [DoctrineType::getType(IntegerEnumType::NAME), FooIntegerEnum::ONE];
-		yield [DoctrineType::getType(StringEnumType::NAME), FooStringEnum::ONE];
-		yield [DoctrineType::getType(BooleanEnumType::NAME), FooBooleanEnum::ENABLED];
+		yield [
+			DoctrineType::getType(FloatEnumType::NAME),
+			FooFloatEnum::ONE,
+		];
+		yield [
+			DoctrineType::getType(IntegerEnumType::NAME),
+			FooIntegerEnum::ONE,
+		];
+		yield [
+			DoctrineType::getType(StringEnumType::NAME),
+			FooStringEnum::ONE,
+		];
+		yield [
+			DoctrineType::getType(BooleanEnumType::NAME),
+			FooBooleanEnum::ENABLED,
+		];
 	}
 
 	/**

--- a/tests/Enum/Type/EnumTypeIntegrationTest.php
+++ b/tests/Enum/Type/EnumTypeIntegrationTest.php
@@ -18,22 +18,22 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function convertEnumToDatabaseDataProvider(): Generator
 	{
-		yield [
+		yield 'float enum' => [
 			'type' => DoctrineType::getType(FloatEnumType::NAME),
 			'enum' => FooFloatEnum::get(FooFloatEnum::ONE),
 			'expectedValue' => FooFloatEnum::ONE,
 		];
-		yield [
+		yield 'integer enum' => [
 			'type' => DoctrineType::getType(IntegerEnumType::NAME),
 			'enum' => FooIntegerEnum::get(FooIntegerEnum::ONE),
 			'expectedValue' => FooIntegerEnum::ONE,
 		];
-		yield [
+		yield 'string enum' => [
 			'type' => DoctrineType::getType(StringEnumType::NAME),
 			'enum' => FooStringEnum::get(FooStringEnum::ONE),
 			'expectedValue' => FooStringEnum::ONE,
 		];
-		yield [
+		yield 'boolean enum' => [
 			'type' => DoctrineType::getType(BooleanEnumType::NAME),
 			'enum' => FooBooleanEnum::get(FooBooleanEnum::ENABLED),
 			'expectedValue' => FooBooleanEnum::ENABLED,
@@ -58,16 +58,16 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function enumTypeDataProvider(): Generator
 	{
-		yield [
+		yield 'float enum' => [
 			'type' => DoctrineType::getType(FloatEnumType::NAME),
 		];
-		yield [
+		yield 'integer enum' => [
 			'type' => DoctrineType::getType(IntegerEnumType::NAME),
 		];
-		yield [
+		yield 'string enum' => [
 			'type' => DoctrineType::getType(StringEnumType::NAME),
 		];
-		yield [
+		yield 'boolean enum' => [
 			'type' => DoctrineType::getType(BooleanEnumType::NAME),
 		];
 	}
@@ -88,19 +88,19 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function convertScalarValueToDatabaseDataProvider(): Generator
 	{
-		yield [
+		yield 'float enum' => [
 			'type' => DoctrineType::getType(FloatEnumType::NAME),
 			'scalarValue' => FooFloatEnum::ONE,
 		];
-		yield [
+		yield 'integer enum' => [
 			'type' => DoctrineType::getType(IntegerEnumType::NAME),
 			'scalarValue' => FooIntegerEnum::ONE,
 		];
-		yield [
+		yield 'string enum' => [
 			'type' => DoctrineType::getType(StringEnumType::NAME),
 			'scalarValue' => FooStringEnum::ONE,
 		];
-		yield [
+		yield 'boolean enum' => [
 			'type' => DoctrineType::getType(BooleanEnumType::NAME),
 			'scalarValue' => FooBooleanEnum::ENABLED,
 		];

--- a/tests/Enum/Type/EnumTypeIntegrationTest.php
+++ b/tests/Enum/Type/EnumTypeIntegrationTest.php
@@ -7,22 +7,21 @@ namespace Consistence\Doctrine\Enum\Type;
 use Consistence\Enum\Enum;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type as DoctrineType;
+use Generator;
 use PHPUnit\Framework\Assert;
 
 class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 {
 
 	/**
-	 * @return mixed[][]
+	 * @return mixed[][]|\Generator
 	 */
-	public function convertEnumToDatabaseDataProvider(): array
+	public function convertEnumToDatabaseDataProvider(): Generator
 	{
-		return [
-			[DoctrineType::getType(FloatEnumType::NAME), FooFloatEnum::get(FooFloatEnum::ONE), FooFloatEnum::ONE],
-			[DoctrineType::getType(IntegerEnumType::NAME), FooIntegerEnum::get(FooIntegerEnum::ONE), FooIntegerEnum::ONE],
-			[DoctrineType::getType(StringEnumType::NAME), FooStringEnum::get(FooStringEnum::ONE), FooStringEnum::ONE],
-			[DoctrineType::getType(BooleanEnumType::NAME), FooBooleanEnum::get(FooBooleanEnum::ENABLED), FooBooleanEnum::ENABLED],
-		];
+		yield [DoctrineType::getType(FloatEnumType::NAME), FooFloatEnum::get(FooFloatEnum::ONE), FooFloatEnum::ONE];
+		yield [DoctrineType::getType(IntegerEnumType::NAME), FooIntegerEnum::get(FooIntegerEnum::ONE), FooIntegerEnum::ONE];
+		yield [DoctrineType::getType(StringEnumType::NAME), FooStringEnum::get(FooStringEnum::ONE), FooStringEnum::ONE];
+		yield [DoctrineType::getType(BooleanEnumType::NAME), FooBooleanEnum::get(FooBooleanEnum::ENABLED), FooBooleanEnum::ENABLED];
 	}
 
 	/**
@@ -39,16 +38,14 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @return \Doctrine\DBAL\Types\Type[][]
+	 * @return \Doctrine\DBAL\Types\Type[][]|\Generator
 	 */
-	public function enumTypeDataProvider(): array
+	public function enumTypeDataProvider(): Generator
 	{
-		return [
-			[DoctrineType::getType(FloatEnumType::NAME)],
-			[DoctrineType::getType(IntegerEnumType::NAME)],
-			[DoctrineType::getType(StringEnumType::NAME)],
-			[DoctrineType::getType(BooleanEnumType::NAME)],
-		];
+		yield [DoctrineType::getType(FloatEnumType::NAME)];
+		yield [DoctrineType::getType(IntegerEnumType::NAME)];
+		yield [DoctrineType::getType(StringEnumType::NAME)];
+		yield [DoctrineType::getType(BooleanEnumType::NAME)];
 	}
 
 	/**
@@ -63,16 +60,14 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @return mixed[][]
+	 * @return mixed[][]|\Generator
 	 */
-	public function convertScalarValueToDatabaseDataProvider(): array
+	public function convertScalarValueToDatabaseDataProvider(): Generator
 	{
-		return [
-			[DoctrineType::getType(FloatEnumType::NAME), FooFloatEnum::ONE],
-			[DoctrineType::getType(IntegerEnumType::NAME), FooIntegerEnum::ONE],
-			[DoctrineType::getType(StringEnumType::NAME), FooStringEnum::ONE],
-			[DoctrineType::getType(BooleanEnumType::NAME), FooBooleanEnum::ENABLED],
-		];
+		yield [DoctrineType::getType(FloatEnumType::NAME), FooFloatEnum::ONE];
+		yield [DoctrineType::getType(IntegerEnumType::NAME), FooIntegerEnum::ONE];
+		yield [DoctrineType::getType(StringEnumType::NAME), FooStringEnum::ONE];
+		yield [DoctrineType::getType(BooleanEnumType::NAME), FooBooleanEnum::ENABLED];
 	}
 
 	/**

--- a/tests/Enum/Type/EnumTypeIntegrationTest.php
+++ b/tests/Enum/Type/EnumTypeIntegrationTest.php
@@ -16,28 +16,42 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	/**
 	 * @return mixed[][]|\Generator
 	 */
-	public function convertEnumToDatabaseDataProvider(): Generator
+	public function enumDataProvider(): Generator
 	{
 		yield 'float enum' => [
 			'type' => DoctrineType::getType(FloatEnumType::NAME),
 			'enum' => FooFloatEnum::get(FooFloatEnum::ONE),
-			'expectedValue' => FooFloatEnum::ONE,
+			'scalarValue' => FooFloatEnum::ONE,
 		];
 		yield 'integer enum' => [
 			'type' => DoctrineType::getType(IntegerEnumType::NAME),
 			'enum' => FooIntegerEnum::get(FooIntegerEnum::ONE),
-			'expectedValue' => FooIntegerEnum::ONE,
+			'scalarValue' => FooIntegerEnum::ONE,
 		];
 		yield 'string enum' => [
 			'type' => DoctrineType::getType(StringEnumType::NAME),
 			'enum' => FooStringEnum::get(FooStringEnum::ONE),
-			'expectedValue' => FooStringEnum::ONE,
+			'scalarValue' => FooStringEnum::ONE,
 		];
 		yield 'boolean enum' => [
 			'type' => DoctrineType::getType(BooleanEnumType::NAME),
 			'enum' => FooBooleanEnum::get(FooBooleanEnum::ENABLED),
-			'expectedValue' => FooBooleanEnum::ENABLED,
+			'scalarValue' => FooBooleanEnum::ENABLED,
 		];
+	}
+
+	/**
+	 * @return mixed[][]|\Generator
+	 */
+	public function convertEnumToDatabaseDataProvider(): Generator
+	{
+		foreach ($this->enumDataProvider() as $caseName => $caseData) {
+			yield $caseName => [
+				'type' => $caseData['type'],
+				'enum' => $caseData['enum'],
+				'expectedValue' => $caseData['scalarValue'],
+			];
+		}
 	}
 
 	/**
@@ -58,18 +72,11 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function enumTypeDataProvider(): Generator
 	{
-		yield 'float enum' => [
-			'type' => DoctrineType::getType(FloatEnumType::NAME),
-		];
-		yield 'integer enum' => [
-			'type' => DoctrineType::getType(IntegerEnumType::NAME),
-		];
-		yield 'string enum' => [
-			'type' => DoctrineType::getType(StringEnumType::NAME),
-		];
-		yield 'boolean enum' => [
-			'type' => DoctrineType::getType(BooleanEnumType::NAME),
-		];
+		foreach ($this->enumDataProvider() as $caseName => $caseData) {
+			yield $caseName => [
+				'type' => $caseData['type'],
+			];
+		}
 	}
 
 	/**
@@ -88,22 +95,12 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function convertScalarValueToDatabaseDataProvider(): Generator
 	{
-		yield 'float enum' => [
-			'type' => DoctrineType::getType(FloatEnumType::NAME),
-			'scalarValue' => FooFloatEnum::ONE,
-		];
-		yield 'integer enum' => [
-			'type' => DoctrineType::getType(IntegerEnumType::NAME),
-			'scalarValue' => FooIntegerEnum::ONE,
-		];
-		yield 'string enum' => [
-			'type' => DoctrineType::getType(StringEnumType::NAME),
-			'scalarValue' => FooStringEnum::ONE,
-		];
-		yield 'boolean enum' => [
-			'type' => DoctrineType::getType(BooleanEnumType::NAME),
-			'scalarValue' => FooBooleanEnum::ENABLED,
-		];
+		foreach ($this->enumDataProvider() as $caseName => $caseData) {
+			yield $caseName => [
+				'type' => $caseData['type'],
+				'scalarValue' => $caseData['scalarValue'],
+			];
+		}
 	}
 
 	/**

--- a/tests/Enum/Type/EnumTypeIntegrationTest.php
+++ b/tests/Enum/Type/EnumTypeIntegrationTest.php
@@ -87,26 +87,13 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @return string[][]
-	 */
-	public function enumTypeClassesProvider(): array
-	{
-		return [
-			[FloatEnumType::class],
-			[IntegerEnumType::class],
-			[StringEnumType::class],
-			[BooleanEnumType::class],
-		];
-	}
-
-	/**
-	 * @dataProvider enumTypeClassesProvider
+	 * @dataProvider enumTypesProvider
 	 *
-	 * @param string $typeClass
+	 * @param \Doctrine\DBAL\Types\Type $type
 	 */
-	public function testGetName(string $typeClass): void
+	public function testGetName(DoctrineType $type): void
 	{
-		$this->assertSame($typeClass::NAME, DoctrineType::getType($typeClass::NAME)->getName());
+		$this->assertSame($type::NAME, $type->getName());
 	}
 
 	/**

--- a/tests/Enum/Type/EnumTypeIntegrationTest.php
+++ b/tests/Enum/Type/EnumTypeIntegrationTest.php
@@ -41,7 +41,7 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	/**
 	 * @return \Doctrine\DBAL\Types\Type[][]
 	 */
-	public function enumTypesProvider(): array
+	public function enumTypeProvider(): array
 	{
 		return [
 			[DoctrineType::getType(FloatEnumType::NAME)],
@@ -52,7 +52,7 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider enumTypesProvider
+	 * @dataProvider enumTypeProvider
 	 *
 	 * @param \Doctrine\DBAL\Types\Type $type
 	 */
@@ -88,7 +88,7 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider enumTypesProvider
+	 * @dataProvider enumTypeProvider
 	 *
 	 * @param \Doctrine\DBAL\Types\Type $type
 	 */
@@ -98,7 +98,7 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider enumTypesProvider
+	 * @dataProvider enumTypeProvider
 	 *
 	 * @param \Doctrine\DBAL\Types\Type $type
 	 */

--- a/tests/Enum/Type/EnumTypeIntegrationTest.php
+++ b/tests/Enum/Type/EnumTypeIntegrationTest.php
@@ -7,6 +7,7 @@ namespace Consistence\Doctrine\Enum\Type;
 use Consistence\Enum\Enum;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type as DoctrineType;
+use PHPUnit\Framework\Assert;
 
 class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 {
@@ -34,7 +35,7 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	public function testConvertEnumToDatabase(DoctrineType $type, Enum $enum, $expectedValue): void
 	{
 		$platform = $this->createMock(AbstractPlatform::class);
-		$this->assertSame($expectedValue, $type->convertToDatabaseValue($enum, $platform));
+		Assert::assertSame($expectedValue, $type->convertToDatabaseValue($enum, $platform));
 	}
 
 	/**
@@ -58,7 +59,7 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	public function testConvertNullToDatabase(DoctrineType $type): void
 	{
 		$platform = $this->createMock(AbstractPlatform::class);
-		$this->assertNull($type->convertToDatabaseValue(null, $platform));
+		Assert::assertNull($type->convertToDatabaseValue(null, $platform));
 	}
 
 	/**
@@ -83,7 +84,7 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	public function testConvertScalarValueToDatabase(DoctrineType $type, $scalarValue): void
 	{
 		$platform = $this->createMock(AbstractPlatform::class);
-		$this->assertSame($scalarValue, $type->convertToDatabaseValue($scalarValue, $platform));
+		Assert::assertSame($scalarValue, $type->convertToDatabaseValue($scalarValue, $platform));
 	}
 
 	/**
@@ -93,7 +94,7 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testGetName(DoctrineType $type): void
 	{
-		$this->assertSame($type::NAME, $type->getName());
+		Assert::assertSame($type::NAME, $type->getName());
 	}
 
 	/**
@@ -104,7 +105,7 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	public function testRequiresSqlCommentHint(DoctrineType $type): void
 	{
 		$platform = $this->createMock(AbstractPlatform::class);
-		$this->assertTrue($type->requiresSQLCommentHint($platform));
+		Assert::assertTrue($type->requiresSQLCommentHint($platform));
 	}
 
 }

--- a/tests/Enum/Type/EnumTypeIntegrationTest.php
+++ b/tests/Enum/Type/EnumTypeIntegrationTest.php
@@ -19,24 +19,24 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	public function convertEnumToDatabaseDataProvider(): Generator
 	{
 		yield [
-			DoctrineType::getType(FloatEnumType::NAME),
-			FooFloatEnum::get(FooFloatEnum::ONE),
-			FooFloatEnum::ONE,
+			'type' => DoctrineType::getType(FloatEnumType::NAME),
+			'enum' => FooFloatEnum::get(FooFloatEnum::ONE),
+			'expectedValue' => FooFloatEnum::ONE,
 		];
 		yield [
-			DoctrineType::getType(IntegerEnumType::NAME),
-			FooIntegerEnum::get(FooIntegerEnum::ONE),
-			FooIntegerEnum::ONE,
+			'type' => DoctrineType::getType(IntegerEnumType::NAME),
+			'enum' => FooIntegerEnum::get(FooIntegerEnum::ONE),
+			'expectedValue' => FooIntegerEnum::ONE,
 		];
 		yield [
-			DoctrineType::getType(StringEnumType::NAME),
-			FooStringEnum::get(FooStringEnum::ONE),
-			FooStringEnum::ONE,
+			'type' => DoctrineType::getType(StringEnumType::NAME),
+			'enum' => FooStringEnum::get(FooStringEnum::ONE),
+			'expectedValue' => FooStringEnum::ONE,
 		];
 		yield [
-			DoctrineType::getType(BooleanEnumType::NAME),
-			FooBooleanEnum::get(FooBooleanEnum::ENABLED),
-			FooBooleanEnum::ENABLED,
+			'type' => DoctrineType::getType(BooleanEnumType::NAME),
+			'enum' => FooBooleanEnum::get(FooBooleanEnum::ENABLED),
+			'expectedValue' => FooBooleanEnum::ENABLED,
 		];
 	}
 
@@ -59,16 +59,16 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	public function enumTypeDataProvider(): Generator
 	{
 		yield [
-			DoctrineType::getType(FloatEnumType::NAME),
+			'type' => DoctrineType::getType(FloatEnumType::NAME),
 		];
 		yield [
-			DoctrineType::getType(IntegerEnumType::NAME),
+			'type' => DoctrineType::getType(IntegerEnumType::NAME),
 		];
 		yield [
-			DoctrineType::getType(StringEnumType::NAME),
+			'type' => DoctrineType::getType(StringEnumType::NAME),
 		];
 		yield [
-			DoctrineType::getType(BooleanEnumType::NAME),
+			'type' => DoctrineType::getType(BooleanEnumType::NAME),
 		];
 	}
 
@@ -89,20 +89,20 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	public function convertScalarValueToDatabaseDataProvider(): Generator
 	{
 		yield [
-			DoctrineType::getType(FloatEnumType::NAME),
-			FooFloatEnum::ONE,
+			'type' => DoctrineType::getType(FloatEnumType::NAME),
+			'scalarValue' => FooFloatEnum::ONE,
 		];
 		yield [
-			DoctrineType::getType(IntegerEnumType::NAME),
-			FooIntegerEnum::ONE,
+			'type' => DoctrineType::getType(IntegerEnumType::NAME),
+			'scalarValue' => FooIntegerEnum::ONE,
 		];
 		yield [
-			DoctrineType::getType(StringEnumType::NAME),
-			FooStringEnum::ONE,
+			'type' => DoctrineType::getType(StringEnumType::NAME),
+			'scalarValue' => FooStringEnum::ONE,
 		];
 		yield [
-			DoctrineType::getType(BooleanEnumType::NAME),
-			FooBooleanEnum::ENABLED,
+			'type' => DoctrineType::getType(BooleanEnumType::NAME),
+			'scalarValue' => FooBooleanEnum::ENABLED,
 		];
 	}
 

--- a/tests/Enum/Type/EnumTypeIntegrationTest.php
+++ b/tests/Enum/Type/EnumTypeIntegrationTest.php
@@ -15,7 +15,7 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	/**
 	 * @return mixed[][]
 	 */
-	public function convertEnumToDatabaseProvider(): array
+	public function convertEnumToDatabaseDataProvider(): array
 	{
 		return [
 			[DoctrineType::getType(FloatEnumType::NAME), FooFloatEnum::get(FooFloatEnum::ONE), FooFloatEnum::ONE],
@@ -26,7 +26,7 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider convertEnumToDatabaseProvider
+	 * @dataProvider convertEnumToDatabaseDataProvider
 	 *
 	 * @param \Doctrine\DBAL\Types\Type $type
 	 * @param \Consistence\Enum\Enum $enum
@@ -41,7 +41,7 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	/**
 	 * @return \Doctrine\DBAL\Types\Type[][]
 	 */
-	public function enumTypeProvider(): array
+	public function enumTypeDataProvider(): array
 	{
 		return [
 			[DoctrineType::getType(FloatEnumType::NAME)],
@@ -52,7 +52,7 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider enumTypeProvider
+	 * @dataProvider enumTypeDataProvider
 	 *
 	 * @param \Doctrine\DBAL\Types\Type $type
 	 */
@@ -65,7 +65,7 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	/**
 	 * @return mixed[][]
 	 */
-	public function convertScalarValueToDatabaseProvider(): array
+	public function convertScalarValueToDatabaseDataProvider(): array
 	{
 		return [
 			[DoctrineType::getType(FloatEnumType::NAME), FooFloatEnum::ONE],
@@ -76,7 +76,7 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider convertScalarValueToDatabaseProvider
+	 * @dataProvider convertScalarValueToDatabaseDataProvider
 	 *
 	 * @param \Doctrine\DBAL\Types\Type $type
 	 * @param mixed $scalarValue
@@ -88,7 +88,7 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider enumTypeProvider
+	 * @dataProvider enumTypeDataProvider
 	 *
 	 * @param \Doctrine\DBAL\Types\Type $type
 	 */
@@ -98,7 +98,7 @@ class EnumTypeIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider enumTypeProvider
+	 * @dataProvider enumTypeDataProvider
 	 *
 	 * @param \Doctrine\DBAL\Types\Type $type
 	 */


### PR DESCRIPTION
- [x] stop calling static methods in tests as non-static
- [x] use assertSame() where assertEquals() is not explicitly needed
- [x] use assertCount() after assertContains() for array comparison
- [x] add missing `Assert::fail()` in `try+catch` blocks when expecting exceptions
- [x] unify `Assert::fail()` message
- [x] replace `Consistence\TestCase::ok()` with `expectNotToPerformAssertions()`
- [x] use `try+catch+fail` when expecting exceptions with properties
- [x] rename data providers to singular where applicable
- [x] use `DataProvider` suffix for data providers
- [x] change data provider return type from `array` to `Generator`
- [x] declare data provider values on separate lines
- [x] isolate data provider cases using Closures
- [x] name data provider values
- [x] name data provider cases
- [x] extract multiple cases from test methods to data providers
- [x] remove unnecessary private methods for creating mocks